### PR TITLE
FIX POS view authentication

### DIFF
--- a/app/views/pos_api.py
+++ b/app/views/pos_api.py
@@ -40,8 +40,8 @@ def get_members():
     return jsonify(data=data), 200
 
 
-@requires_pos_api_key
 @blueprint.route('/get_member_details/<int:_id>/', methods=['GET'])
+@requires_pos_api_key
 def get_member_details(_id=None):
     if not id:
         return jsonify(errors='No user id given'), 400


### PR DESCRIPTION
The requires decorator was placed before the route decorator resulting in unauthorized access to the get_member_detail view.